### PR TITLE
Updated to cpi release 7

### DIFF
--- a/bin/fetch_assets.sh
+++ b/bin/fetch_assets.sh
@@ -3,7 +3,7 @@
 # concourse_version=${concourse_version:-0.45.0}
 concourse_version=${concourse_version:-"0.45.0+dev.1"}
 garden_version=${garden_version:-0.190.0}
-aws_cpi_version=${aws_cpi_version:-5}
+aws_cpi_version=${aws_cpi_version:-7}
 stemcell_version=${stemcell_version:-2830}
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )


### PR DESCRIPTION
Removes dependency on system libxml2
https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release/commit/5a4f720e293e66c2137505e5bc670984e4554474
